### PR TITLE
fix: _generate_*_summary extended methods

### DIFF
--- a/src/rhel_lightspeed_evaluation/extensions/core/output/generator.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/output/generator.py
@@ -165,6 +165,8 @@ class OutputHandlerExt(OutputHandler):
         base_filename: str,
         basic_stats: dict[str, Any],
         detailed_stats: dict[str, Any],
+        api_tokens: dict[str, Any,] | None = None,
+        streaming_stats: dict[str, Any] = None,
     ) -> Path:
         """Generate JSON summary report."""
         json_file = self.output_dir / f"{base_filename}_summary.json"
@@ -203,6 +205,8 @@ class OutputHandlerExt(OutputHandler):
         base_filename: str,
         basic_stats: dict[str, Any],
         detailed_stats: dict[str, Any],
+        api_tokens: dict[str, Any,] | None = None,
+        streaming_stats: dict[str, Any] = None,
     ) -> Path:
         """Generate human-readable text summary."""
         txt_file = self.output_dir / f"{base_filename}_summary.txt"


### PR DESCRIPTION
The methods `_generate_json_summary`  and `_generate_text_summary` were recently updated in the upstream lightspeed-evaluation to have two additional required arguments, causing an error to be raised in this project when calling `generate_report`. Current PR adds the required arguments to the extended methods in this repo. 

Relevant lines upstream:
- [_generate_json_summary](https://github.com/lightspeed-core/lightspeed-evaluation/blob/7dd06466179d19accc7e4bea10212070fbe23483/src/lightspeed_evaluation/core/output/generator.py#L204)
- [_generate_text_summary](https://github.com/lightspeed-core/lightspeed-evaluation/blob/7dd06466179d19accc7e4bea10212070fbe23483/src/lightspeed_evaluation/core/output/generator.py#L267)