### PR TITLE
fix: correct data validator method name to _validate_evaluation_data

### DIFF
--- a/src/rhel_lightspeed_evaluation/extensions/pipeline/evaluation/pipeline.py
+++ b/src/rhel_lightspeed_evaluation/extensions/pipeline/evaluation/pipeline.py
@@ -113,7 +113,7 @@ class EvaluationPipelineExt(EvaluationPipeline):
 
     def validate_data(self, evaluation_data: list[EvaluationData]) -> bool:
         """Validate evaluation data using data validator."""
-        return self.data_validator.validate_evaluation_data(evaluation_data)
+        return self.data_validator._validate_evaluation_data(evaluation_data)
 
     def run_evaluation(
         self,


### PR DESCRIPTION
The method `validate_data` was renamed to `_validate_data` in lightspeed-evaluation recently, resulting in errors calling the method from this project. 