### PR TITLE
Fix API response validation error and missing version attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ make install-dev
    # For Vertex AI
    export GOOGLE_CLOUD_PROJECT="your-cloud-project"
    export GOOGLE_APPLICATION_CREDENTIALS=path/to/credentials.json
+   export GOOGLE_API_KEY=<insert GCP project API individual key>
 
    # For Watsonx
    export WATSONX_API_KEY="your-api-key"

--- a/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
@@ -4,10 +4,10 @@ import logging
 
 import httpx
 from lightspeed_evaluation.core.api import APIClient as BaseAPIClient
-from lightspeed_evaluation.core.models import APIConfig, APIRequest, APIResponse
+from lightspeed_evaluation.core.models import APIConfig, APIRequest
 from lightspeed_evaluation.core.system.exceptions import APIError
 
-from rhel_lightspeed_evaluation.extensions.core.models.api import APIRequestExt
+from rhel_lightspeed_evaluation.extensions.core.models.api import APIRequestExt, APIResponseExt
 from rhel_lightspeed_evaluation.extensions.core.models.system import APIConfigExt
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class APIClientExt(BaseAPIClient):
         query: str,
         conversation_id: str | None = None,
         attachments: list[str] | None = None,
-    ) -> APIResponse:
+    ) -> APIResponseExt:
         """Query the API using the configured endpoint type.
 
         Args:
@@ -89,13 +89,13 @@ class APIClientExt(BaseAPIClient):
             attachments=attachments,
         )
 
-    def _chat_completions_query(self, api_request: APIRequest) -> APIResponse:
+    def _chat_completions_query(self, api_request: APIRequest) -> APIResponseExt:
         """Query the API using chat/completions endpoint."""
         if not self.client:
             raise APIError("HTTP client not initialized")
         try:
             response = self.client.post(
-                f"/{self.version}/chat/completions",
+                f"/{self.config.version}/chat/completions",
                 json=api_request.model_dump(exclude_none=True),
             )
             response.raise_for_status()
@@ -127,7 +127,7 @@ class APIClientExt(BaseAPIClient):
 
             response_data["response"] = response_data["content"]
             response_data["conversation_id"] = response.json()["id"]
-            return APIResponse.from_raw_response(response_data)
+            return APIResponseExt.from_raw_response(response_data)
 
         except httpx.TimeoutException as e:
             raise self._handle_timeout_error("standard", self.timeout) from e

--- a/src/rhel_lightspeed_evaluation/extensions/core/models/api.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/models/api.py
@@ -1,7 +1,24 @@
 from typing import Any
 
-from lightspeed_evaluation.core.models import AttachmentData
+from lightspeed_evaluation.core.models import APIResponse, AttachmentData
 from pydantic import BaseModel, ConfigDict, Field
+
+
+class APIResponseExt(APIResponse):
+    """Extended API response that tolerates null tool_calls."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool_calls: list[list[dict[str, Any]]] | None = Field(
+        default_factory=list, description="Tool call sequences"
+    )
+
+    @classmethod
+    def from_raw_response(cls, raw_data: dict[str, Any]) -> "APIResponseExt":
+        """Create APIResponseExt from raw API response data, normalizing null tool_calls."""
+        if raw_data.get("tool_calls") is None:
+            raw_data["tool_calls"] = []
+        return super().from_raw_response(raw_data)
 
 
 class APIRequestExt(BaseModel):

--- a/src/rhel_lightspeed_evaluation/extensions/core/models/system.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/models/system.py
@@ -198,6 +198,7 @@ class APIConfigExt(APIConfig):
         ...,
         description="API endpoint type (supports 'query', 'streaming', or 'chat/completions')",
     )
+    version: str = Field(default="v1", description="API version prefix for endpoint URLs (e.g., v1, v2)")
     rag: bool = Field(default=False, description="Whether RAG is enabled for the API")
     
     @field_validator("endpoint_type", mode="before")


### PR DESCRIPTION
Summary
- Added APIResponseExt to handle null tool_calls from chat/completions API responses, which caused Pydantic validation failures in the upstream APIResponse model
- Added configurable version field to APIConfigExt (defaults to v1) to fix AttributeError: 'APIClientExt' object has no attribute 'version' when constructing endpoint URLs
- Updated APIClientExt to use APIResponseExt and self.config.version