### PR TITLE
Fix APIClientExt endpoint_type routing for non-chat/completions endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rhel-lightspeed-evaluation"
-version = "0.3.0"
+version = "0.3.1"
 description = "An evaluation project for RHEL Lightspeed using the LSC Evaluation Framework."
 authors=[]
 readme = "README.md"

--- a/src/rhel_lightspeed_evaluation/__init__.py
+++ b/src/rhel_lightspeed_evaluation/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
         EvaluationPipelineExt,
     )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __author__ = "Arin DeLoatch"
 

--- a/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
@@ -1,6 +1,7 @@
 """Extended API client that supports chat/completions endpoint."""
 
 import logging
+from copy import deepcopy
 from typing import Any
 
 import httpx
@@ -39,10 +40,11 @@ class APIClientExt(BaseAPIClient):
     """
 
     def __init__(self, config: APIConfig | APIConfigExt):
-        self._is_chat_completions = config.endpoint_type == "chat/completions"
+        normalized_config = deepcopy(config)
+        self._is_chat_completions = normalized_config.endpoint_type == "chat/completions"
         if self._is_chat_completions:
-            config.endpoint_type = "query"
-        super().__init__(config)
+            normalized_config.endpoint_type = "query"
+        super().__init__(normalized_config)
 
     def query(
         self,

--- a/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
@@ -31,10 +31,17 @@ def _format_tool_calls(raw_tool_calls: list[Any]) -> list[list[dict[str, Any]]]:
 
 
 class APIClientExt(BaseAPIClient):
-    """Extended API client that supports 'chat/completions' endpoint type."""
+    """Extended API client that supports 'chat/completions' endpoint type.
+
+    For chat/completions, overrides the base query() to use _chat_completions_query.
+    For all other endpoint types (infer, streaming, query), delegates to the base
+    class which already handles routing.
+    """
 
     def __init__(self, config: APIConfig | APIConfigExt):
-        config.endpoint_type = "query"
+        self._is_chat_completions = config.endpoint_type == "chat/completions"
+        if self._is_chat_completions:
+            config.endpoint_type = "query"
         super().__init__(config)
 
     def query(
@@ -44,7 +51,10 @@ class APIClientExt(BaseAPIClient):
         attachments: list[str] | None = None,
         extra_request_params: dict[str, Any] | None = None,
     ) -> APIResponseExt:
-        """Query the API using the chat/completions endpoint."""
+        """Query the API using the configured endpoint type."""
+        if not self._is_chat_completions:
+            return super().query(query, conversation_id, attachments, extra_request_params)
+
         if not self.client:
             raise APIError("API client not initialized")
 

--- a/src/rhel_lightspeed_evaluation/extensions/core/models/__init__.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/models/__init__.py
@@ -1,9 +1,13 @@
 from rhel_lightspeed_evaluation.extensions.core.models.system import (
+    AgentsConfigExt,
     APIConfigExt,
+    HttpApiAgentConfigExt,
     SystemConfigExt,
 )
 
 __all__ = [
     "APIConfigExt",
+    "AgentsConfigExt",
+    "HttpApiAgentConfigExt",
     "SystemConfigExt",
 ]

--- a/src/rhel_lightspeed_evaluation/extensions/core/models/system.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/models/system.py
@@ -3,9 +3,24 @@
 Adds support for 'chat/completions' API endpoint type.
 """
 
+
 from lightspeed_evaluation.core.models import APIConfig
+from lightspeed_evaluation.core.models.agents import AgentsConfig, HttpApiAgentConfig
 from lightspeed_evaluation.core.models.system import SystemConfig
 from pydantic import Field, field_validator
+
+EXTENDED_ENDPOINT_TYPES = {"query", "streaming", "chat/completions", "infer"}
+
+
+def _validate_extended_endpoint_type(v: str) -> str:
+    if not isinstance(v, str):
+        raise ValueError("endpoint_type must be a string")
+    v = v.strip()
+    if v not in EXTENDED_ENDPOINT_TYPES:
+        raise ValueError(
+            f"Unsupported endpoint_type: '{v}'. Supported types: {sorted(EXTENDED_ENDPOINT_TYPES)}"
+        )
+    return v
 
 
 class APIConfigExt(APIConfig):
@@ -17,18 +32,23 @@ class APIConfigExt(APIConfig):
     @classmethod
     def validate_endpoint_type(cls, v: str) -> str:
         """Validate endpoint_type is one of the supported values."""
-        if not isinstance(v, str):
-            raise ValueError("endpoint_type must be a string")
+        return _validate_extended_endpoint_type(v)
 
-        v = v.strip()
-        allowed_endpoints = {"query", "streaming", "chat/completions", "infer"}
 
-        if v not in allowed_endpoints:
-            raise ValueError(
-                f"Unsupported endpoint_type: '{v}'. Supported types: {sorted(allowed_endpoints)}"
-            )
+class HttpApiAgentConfigExt(HttpApiAgentConfig):
+    """Extended HTTP API agent config that supports 'chat/completions' endpoint type."""
 
-        return v
+    @field_validator("endpoint_type", mode="before")
+    @classmethod
+    def validate_endpoint_type(cls, v: str) -> str:
+        """Validate endpoint_type is one of the supported values."""
+        return _validate_extended_endpoint_type(v)
+
+
+class AgentsConfigExt(AgentsConfig):
+    """Extended AgentsConfig that uses HttpApiAgentConfigExt."""
+
+    agents: dict[str, HttpApiAgentConfigExt] = Field(default_factory=dict)
 
 
 class SystemConfigExt(SystemConfig):
@@ -37,4 +57,8 @@ class SystemConfigExt(SystemConfig):
     api: APIConfigExt = Field(
         default_factory=lambda: APIConfigExt(**{}),
         description="API configuration (extended to support chat/completions endpoint)",
+    )
+    agents: AgentsConfigExt | None = Field(
+        default=None,
+        description="Agents configuration (extended to support chat/completions endpoint)",
     )


### PR DESCRIPTION
## Summary

- `APIClientExt.__init__` hardcoded `endpoint_type = "query"` and `query()` always routed through `_chat_completions_query`, breaking `endpoint_type: infer` used by lscore-deploy (which exposes `/v1/infer` but not `/v1/chat/completions`)
- The bug was masked by the API response cache (`cache_enabled` defaults to `True`), so previously successful runs appeared to pass validation on subsequent runs
- The upstream `agents` config system (`HttpApiAgentConfig`, `AgentsConfig`) also rejects `chat/completions` as an endpoint type, since its validator only allows `streaming`, `query`, and `infer`
- Both issues are now fixed: `APIClientExt` respects the configured endpoint type, and extended agent config classes accept `chat/completions`

## What changed

### `APIClientExt` (`extensions/core/api/client.py`)

1. **`__init__`**: Only set `endpoint_type = "query"` when the configured type is `chat/completions`. Track this with `self._is_chat_completions`.
2. **`query()`**: For non-chat/completions types, delegate to `super().query()` instead of always running the chat/completions code path.

No changes to `_chat_completions_query`, `_prepare_request`, or any other methods.

### Config model extensions (`extensions/core/models/system.py`)

3. **`HttpApiAgentConfigExt`**: Extends upstream `HttpApiAgentConfig` to accept `chat/completions` as a valid endpoint type.
4. **`AgentsConfigExt`**: Extends upstream `AgentsConfig` to use `HttpApiAgentConfigExt` for agent definitions.
5. **`SystemConfigExt`**: Now overrides the `agents` field to use `AgentsConfigExt`, in addition to the existing `api` field override.
6. Shared `_validate_extended_endpoint_type()` helper used by both `APIConfigExt` and `HttpApiAgentConfigExt` to DRY up validation.

### Other

7. **Version bump**: `0.3.0` → `0.3.1` in `pyproject.toml` and `__init__.py`.

## Why this is safe

- `endpoint_type: chat/completions` follows the exact same code path as before in `APIClientExt`
- `endpoint_type: infer` delegates to `APIClient._rlsapi_infer_query`, which has existed since the infer endpoint was added
- `endpoint_type: streaming` and `query` also delegate to the base class, which has always handled these
- The config extensions only add `chat/completions` to the allowed set — all previously valid values remain valid

## Test plan

- [x] Cleared API cache and `.pyc` files to rule out cached responses
- [x] Removed local workaround in `ls-evaluation-config` that was bypassing `APIClientExt` for `infer`
- [x] Ran eval against lscore-deploy with `endpoint_type: infer` — model validation passed, full eval completed (3 conversations, 18 evaluations)
- [x] Tested with both Gemini (default lscore-deploy) and DeepSeek v3.2 (MaaS via proxy)
- [x] Verified `endpoint_type: chat/completions` passes validation through the new agents config path

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.3.1.

* **New Features**
  * Added support for the "chat/completions" endpoint type in API configuration.
  * Added agents configuration with HTTP API agent settings.

* **Improvements**
  * Improved request routing so chat-style and query-style endpoints are handled appropriately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arin-deloatch/rhel-lightspeed-evaluation/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->