### PR TITLE
feat: add native `vertex_dedicated` provider for self-deployed Vertex AI endpoints

### DIFF
--- a/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import httpx
 from lightspeed_evaluation.core.api import APIClient as BaseAPIClient
-from lightspeed_evaluation.core.models import APIConfig, APIRequest, APIResponse
+from lightspeed_evaluation.core.models import APIConfig, APIRequest
 from lightspeed_evaluation.core.system.exceptions import APIError
 
 from rhel_lightspeed_evaluation.extensions.core.models.api import APIRequestExt, APIResponseExt
@@ -45,6 +45,9 @@ class APIClientExt(BaseAPIClient):
         if self._is_chat_completions:
             normalized_config.endpoint_type = "query"
         super().__init__(normalized_config)
+        if self._is_chat_completions:
+            retry_decorator = self._create_retry_decorator()
+            self._chat_completions_query_with_retry = retry_decorator(self._chat_completions_query)
 
     def query(
         self,
@@ -69,7 +72,7 @@ class APIClientExt(BaseAPIClient):
                 logger.debug("Returning cached response for query: '%s'", query)
                 return cached_response
 
-        response = self._chat_completions_query(api_request)
+        response = self._chat_completions_query_with_retry(api_request)
 
         if self.config.cache_enabled:
             self._add_response_to_cache(api_request, response)
@@ -134,6 +137,8 @@ class APIClientExt(BaseAPIClient):
         except httpx.TimeoutException as e:
             raise self._handle_timeout_error("chat/completions", self.config.timeout) from e
         except httpx.HTTPStatusError as e:
+            if e.response.status_code in (429, 502, 503, 504):
+                raise
             raise self._handle_http_error(e) from e
         except ValueError as e:
             raise self._handle_validation_error(e) from e
@@ -168,7 +173,7 @@ class APIClientExt(BaseAPIClient):
 
             self._format_infer_tool_calls(response_data)
 
-            return APIResponse.from_raw_response(response_data)
+            return APIResponseExt.from_raw_response(response_data)
 
         except httpx.TimeoutException as e:
             raise self._handle_timeout_error("infer", self.config.timeout) from e

--- a/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/api/client.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import httpx
 from lightspeed_evaluation.core.api import APIClient as BaseAPIClient
-from lightspeed_evaluation.core.models import APIConfig, APIRequest
+from lightspeed_evaluation.core.models import APIConfig, APIRequest, APIResponse
 from lightspeed_evaluation.core.system.exceptions import APIError
 
 from rhel_lightspeed_evaluation.extensions.core.models.api import APIRequestExt, APIResponseExt
@@ -141,3 +141,44 @@ class APIClientExt(BaseAPIClient):
             raise
         except Exception as e:
             raise self._handle_unexpected_error(e, "chat/completions query") from e
+
+    def _rlsapi_infer_query(self, api_request):
+        """Override base class to fix duplicate /api/lightspeed/ in URL.
+
+        The base class hardcodes /api/lightspeed/{version}/infer, but api_base
+        already includes /api/lightspeed. This override uses /{version}/infer
+        to avoid the duplicate path.
+        """
+        if not self.client:
+            raise APIError("HTTP client not initialized")
+        try:
+            infer_request = self._build_infer_request(api_request)
+
+            response = self.client.post(
+                f"/{self.config.version}/infer",
+                json=infer_request,
+            )
+            response.raise_for_status()
+
+            response_data = response.json()
+            self._extract_infer_data(response_data)
+
+            if "response" not in response_data:
+                raise APIError("API response missing 'response' field")
+
+            self._format_infer_tool_calls(response_data)
+
+            return APIResponse.from_raw_response(response_data)
+
+        except httpx.TimeoutException as e:
+            raise self._handle_timeout_error("infer", self.config.timeout) from e
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (429, 502, 503, 504):
+                raise
+            raise self._handle_http_error(e) from e
+        except ValueError as e:
+            raise self._handle_validation_error(e) from e
+        except APIError:
+            raise
+        except Exception as e:
+            raise self._handle_unexpected_error(e, "infer query") from e

--- a/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
@@ -1,0 +1,185 @@
+"""Support for self-deployed Vertex AI Model Garden endpoints (vertex_dedicated provider).
+
+Resolves dedicated endpoint DNS at startup, patches LLMManager to handle the
+vertex_dedicated provider, and injects per-call GCP token refresh for dedicated
+endpoint calls.
+
+Usage in YAML config:
+
+    judge_granite:
+      provider: vertex_dedicated
+      model: ibm-granite/granite-4.1-8b
+      parameters:
+        endpoint_id: mg-endpoint-cdd2a610-ffe9-48d8-8370-9ab335a77f7a
+        project: rhel-lightspeed-650189
+        region: us-central1
+
+Applied from run_evaluation(), after vertex_params_patch.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+
+from lightspeed_evaluation.core.llm.manager import LLMManager
+from lightspeed_evaluation.core.system.exceptions import ConfigurationError, LLMError
+
+if TYPE_CHECKING:
+    from lightspeed_evaluation.core.models import LLMConfig
+
+logger = logging.getLogger(__name__)
+
+_gcp_credentials: Any = None
+
+
+def _get_gcp_credentials() -> Any:
+    """Return cached GCP default credentials, loading on first call."""
+    global _gcp_credentials  # noqa: PLW0603
+    if _gcp_credentials is None:
+        import google.auth
+
+        _gcp_credentials, _ = google.auth.default()
+    return _gcp_credentials
+
+
+def _resolve_dedicated_dns(endpoint_id: str, project: str, region: str) -> str:
+    """Resolve dedicated endpoint DNS via the gcloud CLI."""
+    try:
+        result = subprocess.run(
+            [
+                "gcloud",
+                "ai",
+                "endpoints",
+                "describe",
+                endpoint_id,
+                f"--region={region}",
+                f"--project={project}",
+                "--format=value(dedicatedEndpointDns)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        dns = result.stdout.strip()
+        if not dns:
+            stderr = result.stderr.strip()
+            raise ConfigurationError(
+                f"Could not resolve dedicated DNS for endpoint {endpoint_id}: {stderr}"
+            )
+        return dns
+    except FileNotFoundError:
+        raise ConfigurationError(
+            "gcloud CLI not found. "
+            "Install the Google Cloud SDK to use the vertex_dedicated provider."
+        ) from None
+    except subprocess.TimeoutExpired as exc:
+        raise ConfigurationError(
+            f"Timeout resolving dedicated DNS for endpoint {endpoint_id}"
+        ) from exc
+
+
+def _handle_vertex_dedicated(manager: LLMManager) -> str:
+    """Provider handler for vertex_dedicated.
+
+    Resolves the dedicated endpoint DNS, constructs base_url, and returns the
+    model name with an ``openai/`` prefix so litellm routes via the
+    OpenAI-compatible path.
+    """
+    if not os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        raise LLMError(
+            "GOOGLE_APPLICATION_CREDENTIALS environment variable "
+            "is required for the vertex_dedicated provider"
+        )
+
+    params: dict[str, Any] = manager.config.parameters
+    endpoint_id = params.pop("endpoint_id", None)
+    project = params.pop("project", None)
+    region = params.pop("region", None)
+
+    if not all([endpoint_id, project, region]):
+        raise ConfigurationError(
+            "vertex_dedicated provider requires endpoint_id, project, and region "
+            "in parameters"
+        )
+
+    dns = _resolve_dedicated_dns(endpoint_id, project, region)
+    base_url = (
+        f"https://{dns}/v1/projects/{project}"
+        f"/locations/{region}/endpoints/{endpoint_id}"
+    )
+    params["base_url"] = base_url
+    logger.info("Resolved vertex_dedicated endpoint: %s", base_url)
+
+    return f"openai/{manager.config.model}"
+
+
+def _apply_llm_manager_patch() -> None:
+    """Extend LLMManager to recognise the vertex_dedicated provider."""
+    _original_construct = LLMManager._construct_model_name_and_validate
+
+    def _construct_with_vertex_dedicated(self: LLMManager, config: LLMConfig) -> str:
+        if config.provider.lower() == "vertex_dedicated":
+            return _handle_vertex_dedicated(self)
+        return _original_construct(self, config)
+
+    LLMManager._construct_model_name_and_validate = (  # type: ignore[assignment]
+        _construct_with_vertex_dedicated
+    )
+
+
+def _apply_litellm_gcp_refresh() -> None:
+    """Wrap litellm completion functions to refresh GCP tokens for dedicated endpoints."""
+    import lightspeed_evaluation.core.llm.litellm_patch as lp
+
+    _real_completion = lp._original_completion
+    _real_acompletion = lp._original_acompletion
+
+    @wraps(_real_completion)
+    def _completion_with_gcp_refresh(*args: Any, **kwargs: Any) -> Any:
+        if "prediction.vertexai.goog" in str(kwargs.get("api_base") or ""):
+            import google.auth.transport.requests
+
+            creds = _get_gcp_credentials()
+            creds.refresh(google.auth.transport.requests.Request())
+            kwargs["api_key"] = creds.token
+            kwargs.setdefault("extra_body", {})["@requestFormat"] = "chatCompletions"
+            logger.debug("Refreshed GCP token for dedicated endpoint call")
+        return _real_completion(*args, **kwargs)
+
+    @wraps(_real_acompletion)
+    async def _acompletion_with_gcp_refresh(*args: Any, **kwargs: Any) -> Any:
+        if "prediction.vertexai.goog" in str(kwargs.get("api_base") or ""):
+            import google.auth.transport.requests
+
+            creds = _get_gcp_credentials()
+            creds.refresh(google.auth.transport.requests.Request())
+            kwargs["api_key"] = creds.token
+            kwargs.setdefault("extra_body", {})["@requestFormat"] = "chatCompletions"
+            logger.debug("Refreshed GCP token for dedicated endpoint call")
+        return await _real_acompletion(*args, **kwargs)
+
+    lp._original_completion = _completion_with_gcp_refresh
+    lp._original_acompletion = _acompletion_with_gcp_refresh
+
+    try:
+        import rhel_lightspeed_evaluation.extensions.core.llm.vertex_params_patch as vp
+
+        vp._original_completion = _completion_with_gcp_refresh  # type: ignore[attr-defined]
+        vp._original_acompletion = _acompletion_with_gcp_refresh  # type: ignore[attr-defined]
+    except (ImportError, AttributeError):
+        pass
+
+
+def apply_vertex_dedicated_patch() -> None:
+    """Add vertex_dedicated provider support to the framework."""
+    _apply_llm_manager_patch()
+    _apply_litellm_gcp_refresh()
+    logger.info("Applied vertex_dedicated patch for self-deployed Vertex AI endpoints")
+
+
+__all__ = ["apply_vertex_dedicated_patch"]

--- a/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
@@ -10,8 +10,8 @@ Usage in YAML config:
       provider: vertex_dedicated
       model: ibm-granite/granite-4.1-8b
       parameters:
-        endpoint_id: mg-endpoint-cdd2a610-ffe9-48d8-8370-9ab335a77f7a
-        project: rhel-lightspeed-650189
+        endpoint_id: <your-endpoint-id>
+        project: <your-gcp-project>
         region: us-central1
 
 Applied from run_evaluation(), after vertex_params_patch.
@@ -98,12 +98,12 @@ def _handle_vertex_dedicated(manager: LLMManager) -> str:
             "is required for the vertex_dedicated provider"
         )
 
-    params: dict[str, Any] = manager.config.parameters
+    params = dict(manager.config.parameters)
     endpoint_id = params.pop("endpoint_id", None)
     project = params.pop("project", None)
     region = params.pop("region", None)
 
-    if not all([endpoint_id, project, region]):
+    if not all((endpoint_id, project, region)):
         raise ConfigurationError(
             "vertex_dedicated provider requires endpoint_id, project, and region in parameters"
         )
@@ -111,6 +111,7 @@ def _handle_vertex_dedicated(manager: LLMManager) -> str:
     dns = _resolve_dedicated_dns(endpoint_id, project, region)
     base_url = f"https://{dns}/v1/projects/{project}/locations/{region}/endpoints/{endpoint_id}"
     params["base_url"] = base_url
+    manager.config.parameters = params
     logger.info("Resolved vertex_dedicated endpoint: %s", base_url)
 
     return f"openai/{manager.config.model}"

--- a/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
@@ -42,7 +42,9 @@ def _get_gcp_credentials() -> Any:
     if _gcp_credentials is None:
         import google.auth
 
-        _gcp_credentials, _ = google.auth.default()
+        _gcp_credentials, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
     return _gcp_credentials
 
 
@@ -137,7 +139,9 @@ def _apply_litellm_gcp_refresh() -> None:
 
     @wraps(_real_completion)
     def _completion_with_gcp_refresh(*args: Any, **kwargs: Any) -> Any:
-        if "prediction.vertexai.goog" in str(kwargs.get("api_base") or ""):
+        if "prediction.vertexai.goog" in str(
+            kwargs.get("api_base") or kwargs.get("base_url") or ""
+        ):
             import google.auth.transport.requests
 
             creds = _get_gcp_credentials()
@@ -149,7 +153,9 @@ def _apply_litellm_gcp_refresh() -> None:
 
     @wraps(_real_acompletion)
     async def _acompletion_with_gcp_refresh(*args: Any, **kwargs: Any) -> Any:
-        if "prediction.vertexai.goog" in str(kwargs.get("api_base") or ""):
+        if "prediction.vertexai.goog" in str(
+            kwargs.get("api_base") or kwargs.get("base_url") or ""
+        ):
             import google.auth.transport.requests
 
             creds = _get_gcp_credentials()

--- a/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
+++ b/src/rhel_lightspeed_evaluation/extensions/core/llm/vertex_dedicated_patch.py
@@ -103,15 +103,11 @@ def _handle_vertex_dedicated(manager: LLMManager) -> str:
 
     if not all([endpoint_id, project, region]):
         raise ConfigurationError(
-            "vertex_dedicated provider requires endpoint_id, project, and region "
-            "in parameters"
+            "vertex_dedicated provider requires endpoint_id, project, and region in parameters"
         )
 
     dns = _resolve_dedicated_dns(endpoint_id, project, region)
-    base_url = (
-        f"https://{dns}/v1/projects/{project}"
-        f"/locations/{region}/endpoints/{endpoint_id}"
-    )
+    base_url = f"https://{dns}/v1/projects/{project}/locations/{region}/endpoints/{endpoint_id}"
     params["base_url"] = base_url
     logger.info("Resolved vertex_dedicated endpoint: %s", base_url)
 

--- a/src/rhel_lightspeed_evaluation/extensions/pipeline/evaluation/pipeline.py
+++ b/src/rhel_lightspeed_evaluation/extensions/pipeline/evaluation/pipeline.py
@@ -1,8 +1,12 @@
-"""Extended Evaluation Pipeline with chat/completions API client support."""
+"""Extended Evaluation Pipeline with API client support.
+
+Uses APIClientExt for all endpoint types. APIClientExt adds chat/completions
+support and fixes the duplicate /api/lightspeed/ path in the base class's
+infer endpoint handler.
+"""
 
 import logging
 
-from lightspeed_evaluation.core.api import APIClient
 from lightspeed_evaluation.pipeline.evaluation.pipeline import EvaluationPipeline
 
 from rhel_lightspeed_evaluation.extensions.core.api import APIClientExt
@@ -11,10 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 class EvaluationPipelineExt(EvaluationPipeline):
-    """Evaluation pipeline that uses APIClientExt for chat/completions endpoints."""
+    """Evaluation pipeline that uses APIClientExt for all endpoint types."""
 
-    def _create_api_client(self) -> APIClientExt | APIClient | None:
-        """Create API client, using APIClientExt for chat/completions endpoints."""
+    def _create_api_client(self) -> APIClientExt | None:
+        """Create API client using APIClientExt."""
         config = self.config_loader.system_config
         if config is None:
             raise ValueError("SystemConfig must be loaded before creating API client")
@@ -24,10 +28,7 @@ class EvaluationPipelineExt(EvaluationPipeline):
         api_config = config.api
         logger.info("Setting up API client: %s", api_config.api_base)
 
-        if api_config.endpoint_type == "chat/completions":
-            client = APIClientExt(api_config)
-        else:
-            client = APIClient(api_config)
+        client = APIClientExt(api_config)
 
         logger.info("API client initialized for %s endpoint", api_config.endpoint_type)
         return client

--- a/src/rhel_lightspeed_evaluation/extensions/runner/evaluation.py
+++ b/src/rhel_lightspeed_evaluation/extensions/runner/evaluation.py
@@ -129,6 +129,14 @@ def run_evaluation(
 
         apply_vertex_params_patch()
 
+        # Self-deployed Vertex AI Model Garden endpoints need dedicated DNS
+        # resolution and per-call GCP token refresh.
+        from rhel_lightspeed_evaluation.extensions.core.llm.vertex_dedicated_patch import (
+            apply_vertex_dedicated_patch,
+        )
+
+        apply_vertex_dedicated_patch()
+
         from lightspeed_evaluation.core.output import OutputHandler
         from lightspeed_evaluation.core.output.statistics import (
             calculate_api_token_usage,

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -642,7 +641,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -2355,6 +2353,7 @@ dependencies = [
     { name = "ibm-watsonx-ai" },
     { name = "lightspeed-evaluation" },
     { name = "pydantic" },
+    { name = "ruff" },
     { name = "scipy" },
 ]
 
@@ -2378,6 +2377,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.14.11" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "scipy", specifier = ">=1.14.0,<=1.16.2" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },


### PR DESCRIPTION
### Summary

- Add first-class `vertex_dedicated` provider so eval configs can target self-deployed Vertex AI Model Garden endpoints without monkey-patching litellm or running a local proxy
- Fix duplicate `/api/lightspeed/` path in `_rlsapi_infer_query` that caused 504s when using `endpoint_type: infer`

### vertex_dedicated provider

Upstreams the dedicated endpoint logic previously living in `ls-evaluation-config/runner.py` (~100 lines of config rewriting + litellm patching) into the framework as a native provider.

**Config:**
```yaml
llm_pool:
  models:
    judge_granite:
      provider: vertex_dedicated
      model: ibm-granite/granite-4.1-8b
      parameters:
        endpoint_id: <your-endpoint-id>
        project: <your-gcp-project>
        region: us-central1
```

**How it works:**
1. Patches `LLMManager` to handle `vertex_dedicated` — resolves dedicated DNS via `gcloud`, sets `base_url`, returns `openai/{model}` for litellm routing
2. Wraps litellm completion functions to refresh GCP Bearer tokens per-call for `prediction.vertexai.goog` URLs and inject `@requestFormat: chatCompletions`
3. GCP credentials are requested with explicit `cloud-platform` scopes (required in some GCP environments where default scopes are restricted)
4. Applied in `evaluation.py` after `apply_vertex_params_patch()` (order matters for the `_original_completion` reference chain)

### APIClientExt fixes

- **infer URL fix**: The base `lightspeed-evaluation` package hardcodes `/api/lightspeed/{version}/infer` in `_rlsapi_infer_query`, but `api_base` already includes `/api/lightspeed`, producing a doubled path. Override in `APIClientExt` uses `/{version}/infer` to match the pattern used by all other query methods in the base class.
- **Retry support**: Added retry decorator wrapping for `chat/completions` queries, and retryable error re-raise (429/502/503/504) for both `chat/completions` and `infer` endpoints.
- **Always use `APIClientExt`**: The pipeline now uses `APIClientExt` for all endpoint types (not just `chat/completions`) so the infer override is reachable.

### Test plan

- [x] `make lint` passes
- [x] `make type-check` passes
- [x] Tested with mixed judge panel (gemini-2.0-flash + granite-4.1-8b via vertex_dedicated) in ls-evaluation-config
- [x] Verify existing providers (openai, vertex_ai, watsonx) are unaffected

### AI Tools Used

- Claude Code (claude-opus-4-6)

Resolves: [RSPEED-3120](https://redhat.atlassian.net/browse/RSPEED-3120)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled self-deployed Vertex AI Model Garden endpoints with automatic GCP credential management and dedicated endpoint resolution.
  * Improved inference request handling with structured error management for timeouts, rate limiting, service unavailability, and validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arin-deloatch/rhel-lightspeed-evaluation/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->